### PR TITLE
Separate keywords from identifier with tab in keywords.txt

### DIFF
--- a/KEYWORDS.txt
+++ b/KEYWORDS.txt
@@ -6,44 +6,44 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-M2M_LM75A                   KEYWORD1
-FaultQueueValue             KEYWORD1
-OsPolarity                  KEYWORD1
-DeviceMode                  KEYWORD1
+M2M_LM75A	KEYWORD1
+FaultQueueValue	KEYWORD1
+OsPolarity	KEYWORD1
+DeviceMode	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-shutdown                    KEYWORD2
-wakeup                      KEYWORD2
-isShutdown                  KEYWORD2
-getTemperature              KEYWORD2
-getTemperatureInFarenheit   KEYWORD2
-getHysterisisTemperature    KEYWORD2
-getFaultQueueValue          KEYWORD2
-getOSTripTemperature        KEYWORD2
-getOsPolarity               KEYWORD2
-getDeviceMode               KEYWORD2
-setHysterisisTemperature    KEYWORD2
-setOsTripTemperature        KEYWORD2
-setFaultQueueValue          KEYWORD2
-setOsPolarity               KEYWORD2
-setDeviceMode               KEYWORD2
-isConnected                 KEYWORD2
-getConfig                   KEYWORD2
-getProdId                   KEYWORD2
+shutdown	KEYWORD2
+wakeup	KEYWORD2
+isShutdown	KEYWORD2
+getTemperature	KEYWORD2
+getTemperatureInFarenheit	KEYWORD2
+getHysterisisTemperature	KEYWORD2
+getFaultQueueValue	KEYWORD2
+getOSTripTemperature	KEYWORD2
+getOsPolarity	KEYWORD2
+getDeviceMode	KEYWORD2
+setHysterisisTemperature	KEYWORD2
+setOsTripTemperature	KEYWORD2
+setFaultQueueValue	KEYWORD2
+setOsPolarity	KEYWORD2
+setDeviceMode	KEYWORD2
+isConnected	KEYWORD2
+getConfig	KEYWORD2
+getProdId	KEYWORD2
 
 ######################################
 # Constants (LITERAL1)
 #######################################
 
-NUMBER_OF_FAULTS_1          LITERAL1
-NUMBER_OF_FAULTS_2          LITERAL1
-NUMBER_OF_FAULTS_4          LITERAL1
-NUMBER_OF_FAULTS_6          LITERAL1
-OS_POLARITY_ACTIVELOW       LITERAL1
-OS_POLARITY_ACTIVEHIGH      LITERAL1
-DEVICE_MODE_COMPARATOR      LITERAL1
-DEVICE_MODE_INTERRUPT       LITERAL1
+NUMBER_OF_FAULTS_1	LITERAL1
+NUMBER_OF_FAULTS_2	LITERAL1
+NUMBER_OF_FAULTS_4	LITERAL1
+NUMBER_OF_FAULTS_6	LITERAL1
+OS_POLARITY_ACTIVELOW	LITERAL1
+OS_POLARITY_ACTIVEHIGH	LITERAL1
+DEVICE_MODE_COMPARATOR	LITERAL1
+DEVICE_MODE_INTERRUPT	LITERAL1
 


### PR DESCRIPTION
Keyword highlighting only works in the Arduino IDE if the keyword is
separated from the identifier with a tab, per the Arduino Library
Specification:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords
>A tab should be used to separate each name from the KEYWORD1/Keyword2/Literal1 identifier.